### PR TITLE
Removed unused ast import

### DIFF
--- a/models.py
+++ b/models.py
@@ -1,4 +1,3 @@
-from ast import Sub
 from time import time
 from flask_wtf import FlaskForm
 from wtforms import StringField, PasswordField, SubmitField, SelectMultipleField


### PR DESCRIPTION
This must have been a typo while using an IDE. It is rare to import a type from `ast`.